### PR TITLE
Fixed MakeVector4 to construct the vector using x,y,z,w and not w,x,y,z

### DIFF
--- a/src/BasicBehaveEngine/nodes/math/vector/MakeVector4.ts
+++ b/src/BasicBehaveEngine/nodes/math/vector/MakeVector4.ts
@@ -1,7 +1,7 @@
 import {BehaveEngineNode, IBehaviourNodeProps} from "../../../BehaveEngineNode";
 
 export class MakeVector4 extends BehaveEngineNode {
-    REQUIRED_VALUES = [{id:"w"}, {id: "x"}, {id: "y"}, {id: "z"}]
+    REQUIRED_VALUES = [{id:"x"}, {id: "y"}, {id: "z"}, {id: "w"}]
 
     constructor(props: IBehaviourNodeProps) {
         super(props);
@@ -10,7 +10,7 @@ export class MakeVector4 extends BehaveEngineNode {
     }
 
     override processNode(flowSocket?: string) {
-        const {w, x, y, z} = this.evaluateAllValues(this.REQUIRED_VALUES.map(val => val.id));
+        const {x, y, z, w} = this.evaluateAllValues(this.REQUIRED_VALUES.map(val => val.id));
         this.graphEngine.processNodeStarted(this);
         let val: any;
         //console.log(w);
@@ -18,7 +18,7 @@ export class MakeVector4 extends BehaveEngineNode {
         //console.log(y);
         //console.log(z);
 
-        this.outValues.result = {id: "result", value: [w, x, y, z], type: this.getTypeIndex('float4')};
+        this.outValues.result = {id: "result", value: [x, y, z, w], type: this.getTypeIndex('float4')};
 
         return null;
     }

--- a/src/authoring/AuthoringNodeSpecs.ts
+++ b/src/authoring/AuthoringNodeSpecs.ts
@@ -2656,13 +2656,6 @@ export const vectorNodes: IAuthoringNode[] = [
             flows: [],
             values: [
                 {
-                    id: "w",
-                    description: "The first scalar in the vector",
-                    types: [
-                        "float"
-                    ]
-                },
-                {
                     id: "x",
                     description: "The second scalar in the vector",
                     types: [
@@ -2679,6 +2672,13 @@ export const vectorNodes: IAuthoringNode[] = [
                 {
                     id: "z",
                     description: "The fourth scalar in the vector",
+                    types: [
+                        "float"
+                    ]
+                },
+                {
+                    id: "w",
+                    description: "The first scalar in the vector",
                     types: [
                         "float"
                     ]
@@ -2789,7 +2789,7 @@ export const vectorNodes: IAuthoringNode[] = [
     },
     {
         type: "math/make_vector4",
-        description: "Make a vector 4 into an x y and z",
+        description: "Make a vector 4 into an x y z and w",
         configuration: [],
         input: {
             flows: [],
@@ -2815,6 +2815,13 @@ export const vectorNodes: IAuthoringNode[] = [
                         "float"
                     ]
                 },
+                {
+                    id: "w",
+                    description: "Input value",
+                    types: [
+                        "float"
+                    ]
+                }
             ]
         },
         output: {


### PR DESCRIPTION
MakeVector4 was constructing a vector4 using w,x,y,z which is wrong. This change fixes it to use x,y,z,w ordering instead.